### PR TITLE
fix for app.js and https on paperclip uploads plus readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vicarious.li
 
-Vicarious.li is a delightful little web-app designed to do one thing and one thing only: make your dreams a reality via the magic of crowdsourcing.
+Vicarious.li is a delightful little web-app designed to do one thing and one thing only: make your dreams a reality via the magic of crowdfunding.
 
 ![An image of the homepage](https://github.com/bermannoah/repo-images/blob/master/ci_homepage.jpg)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vicarious.li is a delightful little web-app designed to do one thing and one thi
 
 ![An image of the homepage](https://github.com/bermannoah/repo-images/blob/master/ci_homepage.jpg)
 
-## How to use:
+## How to use
 
 The easiest way to go about it is to just go to [https://vicarious.li](https://vicarious.li) and check it out for yourself. You could also clone it down and install it on your own machine, but be aware that you'll need a range of Amazon (AWS) and Twilio keys to make it work.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Vicarious.li
 
+Vicarious.li is a delightful little web-app designed to do one thing and one thing only: make your dreams a reality via the magic of crowdsourcing.
+
+![An image of the homepage](https://github.com/bermannoah/repo-images/blob/master/ci_homepage.jpg)
+
+## How to use:
+
+The easiest way to go about it is to just go to [https://vicarious.li](https://vicarious.li) and check it out for yourself. You could also clone it down and install it on your own machine, but be aware that you'll need a range of Amazon (AWS) and Twilio keys to make it work.
+
+## Technical details
+
+A ruby on rails web app storing data in a PostgreSQL database. Hosted on AWS EC2 with HTTPS provided by the beautiful folks at [Let's Encrypt](https://letsencrypt.org). Some images come from unsplash, but custom ones are handled with a mix of Paperclip + AWS S3. The site is styled via heavily modified bootstrap and some custom jQuery/Ajax magic. 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,11 +10,10 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery.timeago
 //= require jquery
-//= require bootstrap
 //= require jquery_ujs
-//= require turbolinks
+//= require jquery.timeago
+//= require bootstrap
 //= require_tree .
 
 $(document).ready(function(){

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
   
   has_attached_file :banner_image,
+                    :s3_protocol => :https,
                     :styles => {
                                  card: '320x150>',
                                  small: '640x300>',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_password
   
   has_attached_file :avatar,
+                    :s3_protocol => :https,
                     :styles => { comment: '65x65',
                                  thumb: '100x100>',
                                  square: '200x200>',

--- a/spec/features/registered_users/user_can_add_another_user_to_project_owners_spec.rb
+++ b/spec/features/registered_users/user_can_add_another_user_to_project_owners_spec.rb
@@ -21,6 +21,6 @@ describe "User adding user to project owner" do
     click_on "Add This Person"
 
     expect(current_path).to eq(project_path(project.slug))
-    expect(page).to have_content("#{user2.name} Owns this project!")
+    expect(page).to have_content("#{user2.name} owns this project!")
   end
 end


### PR DESCRIPTION
Four small changes:
-- javascript now works in production thanks to a turbolinks removal + a re-ordering of the js requires
-- paperclip/AWS images are now served over HTTPS, as well they should be
-- a test that was failing because I broke it by changing a capital letter to lowercase is now not failing
-- I also added some stuff to the Readme to make it a lil bit more friendly.

(In theory I could close the AWS ticket here but while I am not a superstitious man I am also at least in this regard not an idiot.)

@lsaville @antciccone @bfpepper 
🛌 